### PR TITLE
Fix POSIX time zone string formulation

### DIFF
--- a/tzdump.c
+++ b/tzdump.c
@@ -184,7 +184,7 @@ weekofmonth(int mday, int wday)
 
 	TRACE(("weekofmonth(mday = %d, wday = %d)\n", mday, wday));
 
-	tmp = 1 + mday/7;
+	tmp = 1 + --mday/7;
 	/* Assume that the last week of the month is desired. */
 	if ( tmp == 4 )
 		tmp++;


### PR DESCRIPTION
Week of month calculation was off by one day, possibly due to not
accounting for the fact that mday is 1-based instead of 0-based like all
the other struct tm fields. In the US, that meant that DST would end
Nov 14 instead of Nov 7.