### PR TITLE
fix inconsistent TZ string because of wrong index used to adjust time

### DIFF
--- a/tzdump.c
+++ b/tzdump.c
@@ -633,7 +633,7 @@ dumptzdata(char *tzval)
 #endif /* STRUCT_TZHEAD_TTISGMTCNT */
 			tmptime = tt[i].time
 					+ lti[tt[(i>0)?0:1].type].gmtoffset;
-		if ( lti[i].stds != 0 && lti[tt[i].type].isdst != 0 )
+		if ( lti[tt[i].type].stds != 0 && lti[tt[i].type].isdst != 0 )
 			tmptime += lti[tt[i].type].gmtoffset
 					- lti[tt[(i>0)?0:1].type].gmtoffset;
 		tt[i].tm = gmtime(&tmptime);


### PR DESCRIPTION
It seems the indexes used in lti array to know whether the transition time is standard time were wrong.

For instance, on nov 9, with America/Iqaluit timezone and tzdata-2021a, tzdump gave:

---
$ date
Wed 09 Nov 2022 10:49:45 AM CET
$ tzdump -q -p . America/Iqaluit
EST5EDT,M3.2.0,M11.1.0
---

But that string changed if we set the clock on 1 september:

---
$ sudo date -s "1 SEP 2022 11:00:00"
$ date
Thu 01 Sep 2022 11:02:23 AM CEST
$ tzdump -q -p . America/Iqaluit
EST5EDT,M3.2.0/3,M11.1.0
---